### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/hex.t
+++ b/t/hex.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More;
 use lib 'lib';
 
-use_ok 'Math::HexGrid::Hex', 'import module';
+use_ok 'Math::HexGrid::Hex';
 ok my $hex = Math::HexGrid::Hex->new(-2,2,0), 'constructor';
 ok my $hex2 = Math::HexGrid::Hex->new(-2,2), 'constructor';
 ok $hex->hex_equal($hex2), 'hexes are equal';

--- a/t/hexgrid.t
+++ b/t/hexgrid.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 'lib';
 use Test::More;
 
-use_ok 'Math::HexGrid', 'import module';
+use_ok 'Math::HexGrid';
 
 # hexagon shape
 ok my $hexgrid = Math::HexGrid->new_hexagon(2), 'create a hexagon';


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.